### PR TITLE
Make admin users room owners even without token

### DIFF
--- a/mod_token_moderation.lua
+++ b/mod_token_moderation.lua
@@ -6,6 +6,11 @@ local log = module._log;
 local jid_bare = require "util.jid".bare;
 local json = require "cjson";
 local basexx = require "basexx";
+local um_is_admin = require "core.usermanager".is_admin;
+
+local function is_admin(jid)
+        return um_is_admin(jid, module.host);
+end
 
 log('info', 'Loaded token moderation plugin');
 -- Hook into room creation to add this wrapper to every new room
@@ -49,14 +54,14 @@ function setupAffiliation(room, origin, stanza)
                         if dotSecond then
                                 local bodyB64 = origin.auth_token:sub(dotFirst + 1, dotFirst + dotSecond - 1);
                                 local body = json.decode(basexx.from_url64(bodyB64));
-                                -- If user is a moderator, set their affiliation to be an owner
-                                if body["moderator"] == true then
-                                        room:set_affiliation("token_plugin", jid_bare(stanza.attr.from), "owner");
+                                local jid = jid_bare(stanza.attr.from);
+                                -- If user is a moderator or an admin, set their affiliation to be an owner
+                                if body["moderator"] == true or is_admin(jid) then
+                                        room:set_affiliation("token_plugin", jid, "owner");
                                 else
-                                        room:set_affiliation("token_plugin", jid_bare(stanza.attr.from), "member");
+                                        room:set_affiliation("token_plugin", jid, "member");
                                 end;
 			end;
 		end;
 	end;
 end;
-                        


### PR DESCRIPTION
It may be important that the 'focus' Jicofo user can be an owner in
addition to people with moderator tokens. Without that, if the
moderator leaves the room (eg looses connection) then another user
will be made the new moderator, even if their token doesn't say they
should be. This change allows the focus user to be the owner so that
won't happen, so long as they're in the 'admins' setting in the
Prosody configuration.